### PR TITLE
Add Notification model and functionality

### DIFF
--- a/app/controllers/spree/store_controller_decorator.rb
+++ b/app/controllers/spree/store_controller_decorator.rb
@@ -1,0 +1,5 @@
+module Spree
+  StoreController.class_eval do
+    before_action SpreeNotifications::ControllerFilters
+  end
+end

--- a/app/models/spree_notifications/notification.rb
+++ b/app/models/spree_notifications/notification.rb
@@ -1,0 +1,22 @@
+class SpreeNotifications::Notification < ActiveRecord::Base
+  belongs_to :user, class_name: Spree::User
+
+  validates :severity, :message, presence: true
+  validate :validates_presence_of_either_guest_token_or_user_id
+
+  def self.for(guest_token_or_user)
+    if guest_token_or_user.respond_to?(:id)
+      where(user_id: guest_token_or_user.id)
+    else
+      where(guest_token: guest_token_or_user)
+    end
+  end
+
+  private
+
+  def validates_presence_of_either_guest_token_or_user_id
+    if guest_token.blank? && user_id.blank?
+      errors.add(:base, "both guest_token and user_id can't be blank")
+    end
+  end
+end

--- a/db/migrate/20150923201432_create_spree_notifications_notifications.rb
+++ b/db/migrate/20150923201432_create_spree_notifications_notifications.rb
@@ -1,0 +1,12 @@
+class CreateSpreeNotificationsNotifications < ActiveRecord::Migration
+  def change
+    create_table :spree_notifications_notifications do |t|
+      t.string :severity, null: false
+      t.text :message, null: false
+      t.string :guest_token
+      t.integer :user_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/lib/spree_notifications.rb
+++ b/lib/spree_notifications.rb
@@ -1,2 +1,15 @@
 require 'spree_core'
 require 'spree_notifications/engine'
+require 'spree_notifications/controller_filters'
+
+module SpreeNotifications
+  def self.table_name_prefix
+    'spree_notifications_'
+  end
+
+  def self.create(severity, message, options)
+    SpreeNotifications::Notification.create!(
+      options.merge(severity: severity.to_s, message: message)
+    )
+  end
+end

--- a/lib/spree_notifications/controller_filters.rb
+++ b/lib/spree_notifications/controller_filters.rb
@@ -1,0 +1,28 @@
+module SpreeNotifications
+  module ControllerFilters
+    # This method will be called by before_action controller callback
+    def self.before(controller)
+      LoadNotifications.new(controller).perform
+    end
+
+    class LoadNotifications
+      def initialize(controller)
+        @controller = controller
+      end
+
+      def perform
+        Notification.for(lookup_token).each do |notification|
+          @controller.flash.now[notification.severity] = notification.message
+          notification.destroy
+        end
+      end
+
+      private
+
+      def lookup_token
+        @controller.spree_current_user ||
+          @controller.send(:cookies).signed[:guest_token]
+      end
+    end
+  end
+end

--- a/lib/spree_notifications/factories.rb
+++ b/lib/spree_notifications/factories.rb
@@ -1,6 +1,11 @@
 FactoryGirl.define do
-  # Define your Spree extensions Factories within this file to enable applications, and other extensions to use and override them.
-  #
-  # Example adding this to your spec_helper will load these Factories for use:
-  # require 'spree_notifications/factories'
+  factory :notification, class: SpreeNotifications::Notification do
+    severity "warn"
+    message "Warning! Warning!"
+    guest_token SecureRandom.urlsafe_base64(nil, false)
+
+    trait :registered_user do
+      user
+    end
+  end
 end

--- a/spec/controllers/spree/store_controller_spec.rb
+++ b/spec/controllers/spree/store_controller_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+
+RSpec.describe Spree::StoreController do
+  controller do
+    def index
+      render text: flash.to_hash.map { |key, value| "#{key}: #{value}" }.join
+    end
+  end
+
+  before do
+    create(:notification, guest_token: guest_token, message: "Guest!")
+    create(:notification, message: "Nope!")
+    create(:notification, :registered_user, message: "User!")
+  end
+
+  let(:guest_token) do
+    get :index
+    cookies.signed[:guest_token]
+  end
+
+  context "when user is not logged in" do
+    it "loads notification based on the guest token" do
+      get :index
+
+      expect(response.body).to include "Guest!"
+      expect(response.body).not_to include "Nope!"
+      expect(response.body).not_to include "User!"
+    end
+  end
+
+  context "when user is logged in" do
+    it "loads notification based on user" do
+      sign_in Spree::User.last
+
+      get :index
+
+      expect(response.body).not_to include "Guest!"
+      expect(response.body).not_to include "Nope!"
+      expect(response.body).to include "User!"
+    end
+  end
+end

--- a/spec/features/background_notification_spec.rb
+++ b/spec/features/background_notification_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+
+RSpec.feature "Background notification" do
+  let(:warning) { "Something is happening!" }
+
+  scenario "displays as flash message to guest" do
+    SpreeNotifications.create(:warn, warning, guest_token: guest_token)
+
+    visit spree.root_path
+
+    expect(page).to have_selector(".alert-warn", text: warning)
+  end
+
+  scenario "displays as flash message to registered user" do
+    user = create(:user)
+    sign_in_as user
+    SpreeNotifications.create(:warn, warning, user_id: user.id)
+
+    visit spree.root_path
+
+    expect(page).to have_selector(".alert-warn", text: warning)
+  end
+
+  scenario "clears the message after it was displayed" do
+    SpreeNotifications.create(:warn, warning, guest_token: guest_token)
+
+    visit spree.root_path
+    visit spree.root_path
+
+    expect(page).not_to have_content(warning)
+  end
+
+  def guest_token
+    # Visit a page so Spree will generate a guest token in cookie
+    visit spree.root_path
+    cookie_jar.signed["guest_token"]
+  end
+
+  def cookie_jar
+    ActionDispatch::Cookies::CookieJar.build(page.driver.request).tap do |jar|
+      jar.update(page.driver.browser.rack_mock_session.cookie_jar.to_hash)
+    end
+  end
+end

--- a/spec/models/spree_notifications/notification_spec.rb
+++ b/spec/models/spree_notifications/notification_spec.rb
@@ -1,0 +1,59 @@
+require "spec_helper"
+
+RSpec.describe SpreeNotifications::Notification do
+  it { should belong_to :user }
+
+  it { should validate_presence_of :severity }
+  it { should validate_presence_of :message }
+
+  describe "#validate" do
+    context "with both guest_token and user_id are nil" do
+      it "fails the validation" do
+        notification = build(:notification, guest_token: nil, user_id: nil)
+
+        expect(notification).not_to be_valid
+        expect(notification.errors[:base]).
+          to eq ["both guest_token and user_id can't be blank"]
+      end
+    end
+
+    context "with only guest_token given" do
+      it "passes the validation" do
+        notification = build(:notification, guest_token: "ABCDE")
+
+        expect(notification).to be_valid
+      end
+    end
+
+    context "with only user_id given" do
+      it "passes the validation" do
+        user = build_stubbed(:user)
+        notification = build(:notification, :registered_user, user_id: user.id)
+
+        expect(notification).to be_valid
+      end
+    end
+  end
+
+  describe ".for" do
+    context "with a guest token" do
+      it "returns all notifications associated with that guest_token" do
+        guest_notification = create(:notification, guest_token: "ABCDE")
+        create(:notification, :registered_user)
+
+        expect(SpreeNotifications::Notification.for("ABCDE")).
+          to eq [guest_notification]
+      end
+    end
+
+    context "with a user object" do
+      it "returns all notifications associated with that user" do
+        user_notification = create(:notification, :registered_user)
+        create(:notification)
+
+        expect(SpreeNotifications::Notification.for(user_notification.user)).
+          to eq [user_notification]
+      end
+    end
+  end
+end

--- a/spec/spree_notifications_spec.rb
+++ b/spec/spree_notifications_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe SpreeNotifications do
+  describe ".create" do
+    it "creates SpreeNotifications::Notification database record" do
+      allow(SpreeNotifications::Notification).to receive(:create!)
+
+      SpreeNotifications.create(:warn, "message", guest_token: "token")
+
+      expect(SpreeNotifications::Notification).
+        to have_received(:create!).
+          with(severity: "warn", message: "message", guest_token: "token")
+    end
+  end
+end

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -1,0 +1,12 @@
+module AuthenticationHelpers
+  def sign_in_as(user)
+    visit '/login'
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: 'secret'
+    click_button 'Login'
+  end
+end
+
+RSpec.configure do |config|
+  config.include AuthenticationHelpers, type: :feature
+end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include Devise::TestHelpers, type: :controller
+end

--- a/spec/support/shoulda-matchers.rb
+++ b/spec/support/shoulda-matchers.rb
@@ -1,0 +1,8 @@
+require "shoulda/matchers"
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/spree_notifications.gemspec
+++ b/spree_notifications.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails',  '~> 3.1'
   s.add_development_dependency 'sass-rails', '~> 5.0.0.beta1'
   s.add_development_dependency 'selenium-webdriver'
+  s.add_development_dependency 'shoulda-matchers'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
 end


### PR DESCRIPTION
* Use `SpreeNotifications.create` to create notification for a particular user or guest (based on guest_token).
* Notification can be created in the background.
* Notification will be loaded and stored in flash message, then destroyed from the database.